### PR TITLE
ci: Remove preflight check step

### DIFF
--- a/.github/workflows/appmap-archive.yml
+++ b/.github/workflows/appmap-archive.yml
@@ -26,7 +26,7 @@ jobs:
           ln -s /usr/local/bin/appmap /tmp/appmap
 
       - name: Build AppMaps
-        run: yarn appmap
+        run: yarn test
 
       - name: Archive AppMaps
         uses: getappmap/archive-appmap-action@v1-pre.10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn build
 
       - name: Test
-        run: yarn appmap || true
+        run: yarn test
 
       - name: Preflight
         id: preflight
@@ -40,11 +40,6 @@ jobs:
           base-revision: origin/main
           head-revision: ${{ github.event.pull_request.head.sha }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check test status
-        uses: ./check
-        with:
-          directory: ${{ steps.preflight.outputs.report-dir }}
 
       - name: Build GitHub action
         run: yarn package

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "watch": "tsc --watch",
     "package": "ncc build -o dist/preflight --source-map src/preflight.ts && ncc build -o dist/check --source-map src/check.ts",
     "build": "yarn compile && yarn package",
-    "test": "jest --runInBand",
-    "appmap": "appmap-agent-js -- jest --runInBand --no-cache",
+    "test": "appmap-agent-js -- jest --runInBand --no-cache",
     "clean": "rm -rf build dist tmp",
     "format": "prettier --write '**/*.ts'"
   },


### PR DESCRIPTION
AppMap JS does not report test_failure, so preflight/check can't be used.