### PR TITLE
feat: Make the runners configurable for larger/different instances

### DIFF
--- a/.github/workflows/appmap-analysis-matrix.yml
+++ b/.github/workflows/appmap-analysis-matrix.yml
@@ -6,11 +6,16 @@ on:
       archive-count:
         required: true
         type: number
+      runner-name:
+        required: false
+        type: string
+        default: ubuntu-latest
+    
 jobs:
   analyze:
     # If your organization has 4-core runners available, you should change this line to use
     # those runners. 4 cores offers the best performance for AppMap analysis.
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-name }}
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/appmap-analysis.yml
+++ b/.github/workflows/appmap-analysis.yml
@@ -2,6 +2,11 @@ name: AppMap Analysis
 
 on:
   workflow_call:
+    inputs:
+      runner-name:
+        required: false
+        type: string
+        default: ubuntu-latest
 
 jobs:
   analyze:

--- a/.github/workflows/appmap-analysis.yml
+++ b/.github/workflows/appmap-analysis.yml
@@ -12,7 +12,7 @@ jobs:
   analyze:
     # If your organization has 4-core runners available, you should change this line to use
     # those runners. 4 cores offers the best performance for AppMap analysis.
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-name }}
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
I ran into an issue on the [Forem testing ](https://github.com/getappmap/forem/actions/runs/6114686842) where the runner that did the analysis ran out of disk storage.  

This allows someone to pass an updated `runs-on` runner name to the reusable workflow so that a user can define a larger runner name to the workflow.  

[Here is a test run](https://github.com/land-of-apps/rails_tutorial_sample_app_7th_ed/actions/runs/6121705848) of this branch where i'm not explicitly setting the runner-name and therefore it uses the default configuration. 

[Here is the test run on the test Forem project](https://github.com/getappmap/forem/actions/runs/6121430535/job/16615914873#step:1:2) where i've passed along the name of the runner and it gets picked up correctly.  

