### PR TITLE
Add archive-retention-days as an input for the reusable workflows

### DIFF
--- a/.github/workflows/appmap-analysis-matrix.yml
+++ b/.github/workflows/appmap-analysis-matrix.yml
@@ -3,6 +3,10 @@ name: AppMap Analysis
 on:
   workflow_call:
     inputs:
+      archive-retention-days:
+        required: false
+        type: number
+        default: 7
       archive-count:
         required: true
         type: number
@@ -47,6 +51,7 @@ jobs:
         uses: getappmap/analyze-action@v1
         if: (success() || failure()) && github.event_name == 'pull_request'
         with:
+          archive-retention-days: ${{ inputs.archive-retention-days }}
           directory: ${{ inputs.directory }}
           base-revision: ${{ github.event.pull_request.base.sha }}
           head-revision: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/appmap-analysis.yml
+++ b/.github/workflows/appmap-analysis.yml
@@ -3,6 +3,10 @@ name: AppMap Analysis
 on:
   workflow_call:
     inputs:
+      archive-retention-days:
+        required: false
+        type: number
+        default: 7
       runner-name:
         required: false
         type: string
@@ -51,6 +55,7 @@ jobs:
         uses: getappmap/analyze-action@v1
         if: github.event_name == 'pull_request'
         with:
+          archive-retention-days: ${{ inputs.archive-retention-days }}
           directory: ${{ inputs.directory }}
           base-revision: ${{ github.event.pull_request.base.sha }}
           head-revision: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This is mostly so that our demo projects can be set with a much longer retention window so that we don't need to continually re-generate the archives.  But i'm sure others may want this feature to be adjustable more easily.  